### PR TITLE
Mark cobra required flags in usage

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -698,6 +698,9 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 		} else {
 			line = fmt.Sprintf("      --%s", flag.Name)
 		}
+		if val, ok := flag.Annotations["cobra_annotation_bash_completion_one_required_flag"]; ok && len(val) > 0 && val[0] == "true" {
+			line += " (*)"
+		}
 
 		varname, usage := UnquoteUsage(flag)
 		if varname != "" {


### PR DESCRIPTION
Adds a (*) sign to flags with the cobra required annotation.

Sample result:
      --destination (*) string   The path to the download dir. Defaults to some random dir /tmp/datamon-mount-destination{xxxxx}
  -h, --help                     help for download
      --label string             The human-readable name of a label
      --name-filter string       A regular expression (RE2) to match names of bundle entries.
      --repo (*) string          The name of this repository

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>